### PR TITLE
Add doping test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 [![Build Status](https://travis-ci.org/mlubin/JuGP.jl.svg?branch=master)](https://travis-ci.org/mlubin/JuGP.jl)
 
 Julia for Geometric Programming (JuGP), a JuMP extension. This is research code, use at your own risk.
+
+Geometric Programming Resources:
+
+  * ["A tutorial on geometric programming" by Boyd, et al.](http://stanford.edu/~boyd/papers/pdf/gp_tutorial.pdf)

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,7 @@
 
 # inspiration from Iain's initial work at https://github.com/IainNZ/GPTest
 
-import Base: (*), (+), (-), (/)
+import Base: (*), (+), (-), (/), (^)
 
 abstract Xial
 
@@ -26,7 +26,7 @@ end
 type Posynomial <: Xial
     mons::Vector{Monomial}
 end
-function Base.print(io::IO, pos::Posynomial)    
+function Base.print(io::IO, pos::Posynomial)
     if length(pos.mons) == 0
         print(io, "0")
     elseif length(pos.mons) == 1
@@ -49,6 +49,8 @@ function (/)(num::Number, m::Monomial)
 end
 (-)(m::Monomial, num::Number) = m - Monomial(num)
 (-)(num::Number, m::Monomial) = Monomial(num) - m
+(^)(m::Monomial, num::Number) = Monomial(m.c^num,
+                                    Dict{Int,Float64}([i => m.terms[i]*num for i in keys(m.terms)]))
 # Mon-Mon
 (+)(m::Monomial, n::Monomial) = Posynomial([m,n])
 (-)(m::Monomial, n::Monomial) = Posynomial([m,-1*n])


### PR DESCRIPTION
Currently fails with

```
  MethodError: `^` has no method matching ^(::JuGP.Monomial, ::Float64)
  Closest candidates are:
    ^(::Float64, ::Float64)
    ^(::Irrational{:e}, ::Number)
    ^(::ForwardDiff.GradientNumber{N,T,C}, ::Real)
    ...
   in _mapreduce at reduce.jl:145
   in mapreduce at reduce.jl:159
   in mapreduce at reduce.jl:162
   in descend at /Users/idunning/.julia/v0.4/JuGP/src/expr.jl:29
   in descend at /Users/idunning/.julia/v0.4/JuGP/src/expr.jl:23 (repeats 2 times)
   in check_expr_gp at /Users/idunning/.julia/v0.4/JuGP/src/expr.jl:35
```
